### PR TITLE
Add error handling around STEP import logic

### DIFF
--- a/src/app.js
+++ b/src/app.js
@@ -1,68 +1,62 @@
 // Three.js via CDN modules
+try {
+  const params = { linearUnit: 'millimeter', linearDeflectionType: 'bounding_box_ratio', linearDeflection: 0.001, angularDeflection: 0.5 };
+  const result = occt.ReadStepFile(uint8, params);
+  if(!result || !result.success){
+    throw new Error('STEP import failed.');
+  }
 
+  const group = new THREE.Group();
+  let bounds = null;
+  for(const m of result.meshes){
+    // Build a BufferGeometry from OCCT result, with fallbacks for field names
+    const posSrc = (m.attributes && m.attributes.position && m.attributes.position.array)
+      ? m.attributes.position.array
+      : (m.position || m.positions || m.vertices);
+    if(!posSrc) continue;
+    const pos = posSrc.BYTES_PER_ELEMENT ? new Float32Array(posSrc) : new Float32Array(posSrc);
 
-const params = { linearUnit: 'millimeter', linearDeflectionType: 'bounding_box_ratio', linearDeflection: 0.001, angularDeflection: 0.5 };
-const result = occt.ReadStepFile(uint8, params);
-if(!result || !result.success){
-throw new Error('STEP import failed.');
-}
+    const geo = new THREE.BufferGeometry();
+    geo.setAttribute('position', new THREE.Float32BufferAttribute(pos, 3));
 
+    const idxSrc = (m.index && m.index.array) ? m.index.array : (m.indices || m.index);
+    if(idxSrc){
+      const typed = (idxSrc.length > 65535) ? new Uint32Array(idxSrc) : new Uint16Array(idxSrc);
+      geo.setIndex(new THREE.BufferAttribute(typed, 1));
+    }
+    geo.computeVertexNormals();
 
-const group = new THREE.Group();
-let bounds = null;
-for(const m of result.meshes){
-// Build a BufferGeometry from OCCT result, with fallbacks for field names
-const posSrc = (m.attributes && m.attributes.position && m.attributes.position.array)
-? m.attributes.position.array
-: (m.position || m.positions || m.vertices);
-if(!posSrc) continue;
-const pos = posSrc.BYTES_PER_ELEMENT ? new Float32Array(posSrc) : new Float32Array(posSrc);
+    const colorObj = (m.color && m.color.length === 3)
+      ? new THREE.Color(m.color[0], m.color[1], m.color[2])
+      : new THREE.Color(0x3c8bff);
+    const mat = new THREE.MeshStandardMaterial({ color: colorObj, metalness: 0.05, roughness: 0.6 });
+    const mesh = new THREE.Mesh(geo, mat);
+    group.add(mesh);
 
+    const bb = computeBoundsFromPositions(pos);
+    bounds = bounds ? bounds.union(bb) : bb;
+  }
 
-const geo = new THREE.BufferGeometry();
-geo.setAttribute('position', new THREE.Float32BufferAttribute(pos, 3));
+  if(!bounds){
+    throw new Error('No geometry produced from STEP.');
+  }
 
+  scene.add(group);
+  const dimsMm = dimsFromBounds(bounds);
+  const boxHelper = addBoundingBoxHelper(bounds);
 
-const idxSrc = (m.index && m.index.array) ? m.index.array : (m.indices || m.index);
-if(idxSrc){
-const typed = (idxSrc.length > 65535) ? new Uint32Array(idxSrc) : new Uint16Array(idxSrc);
-geo.setIndex(new THREE.BufferAttribute(typed, 1));
-}
-geo.computeVertexNormals();
+  const name = `${file.name}`;
+  const prec = parseInt(precisionEl.value, 10) || 3;
+  const card = addCard(name, `<div class=\"ok\">Loaded STEP (converted → mm).</div>${formatDims(dimsMm, prec)}`);
+  card.addEventListener('click', ()=>{ centerAndFrame(bounds); });
+  centerAndFrame(bounds);
 
-
-const colorObj = (m.color && m.color.length === 3)
-? new THREE.Color(m.color[0], m.color[1], m.color[2])
-: new THREE.Color(0x3c8bff);
-const mat = new THREE.MeshStandardMaterial({ color: colorObj, metalness: 0.05, roughness: 0.6 });
-const mesh = new THREE.Mesh(geo, mat);
-group.add(mesh);
-
-
-const bb = computeBoundsFromPositions(pos);
-bounds = bounds ? bounds.union(bb) : bb;
-}
-
-
-if(!bounds){
-throw new Error('No geometry produced from STEP.');
-}
-
-
-scene.add(group);
-const dimsMm = dimsFromBounds(bounds);
-const boxHelper = addBoundingBoxHelper(bounds);
-
-
-const name = `${file.name}`;
-const prec = parseInt(precisionEl.value, 10) || 3;
-const card = addCard(name, `<div class=\"ok\">Loaded STEP (converted → mm).</div>${formatDims(dimsMm, prec)}`);
-card.addEventListener('click', ()=>{ centerAndFrame(bounds); });
-centerAndFrame(bounds);
-
-
-models.push({ name, group, bounds, unit: 'mm', kind: 'step', helper: boxHelper });
+  models.push({ name, group, bounds, unit: 'mm', kind: 'step', helper: boxHelper });
+} catch (err) {
+  console.error('Failed to import STEP file.', err);
+  const displayName = (file && file.name) ? `${file.name}` : 'STEP file';
+  addCard(displayName, `<div class=\"warn\">Failed to load STEP: ${err.message || err}</div>`);
 } finally {
-loading.classList.remove('show');
+  loading.classList.remove('show');
 }
 }


### PR DESCRIPTION
## Summary
- wrap the STEP parsing routine in a try/catch so the existing finally block has a matching try
- log STEP import failures and surface a warning card when parsing fails

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68dc5ed25a8c832b9fb2e25784941232