### PR TITLE
Fix Three.js example imports for browser usage

### DIFF
--- a/src/app.js
+++ b/src/app.js
@@ -1,7 +1,7 @@
 // Three.js via CDN modules (ESM) and helpers from the examples directory.
 import * as THREE from 'https://unpkg.com/three@0.160.0/build/three.module.js';
-import { OrbitControls } from 'https://unpkg.com/three@0.160.0/examples/jsm/controls/OrbitControls.js';
-import { STLLoader } from 'https://unpkg.com/three@0.160.0/examples/jsm/loaders/STLLoader.js';
+import { OrbitControls } from 'https://unpkg.com/three@0.160.0/examples/jsm/controls/OrbitControls.js?module';
+import { STLLoader } from 'https://unpkg.com/three@0.160.0/examples/jsm/loaders/STLLoader.js?module';
 
 const scene = new THREE.Scene();
 scene.background = new THREE.Color(0x0b1020);


### PR DESCRIPTION
## Summary
- append the `?module` query parameter to the OrbitControls and STLLoader CDN imports so unpkg rewrites bare specifiers
- ensure the Three.js helper modules load without a module resolution error

## Testing
- python -m http.server 8000
- playwright script to upload STL file

------
https://chatgpt.com/codex/tasks/task_e_68dc6a6a1ee8832b9c2d4be44e93c371