### PR TITLE
Fix duplicate Three.js import warning

### DIFF
--- a/index.html
+++ b/index.html
@@ -61,6 +61,15 @@
 </div>
 
 
+<script type="importmap">
+  {
+    "imports": {
+      "three": "https://unpkg.com/three@0.160.0/build/three.module.js",
+      "three/examples/jsm/controls/OrbitControls.js": "https://unpkg.com/three@0.160.0/examples/jsm/controls/OrbitControls.js",
+      "three/examples/jsm/loaders/STLLoader.js": "https://unpkg.com/three@0.160.0/examples/jsm/loaders/STLLoader.js"
+    }
+  }
+</script>
 <script type="module" src="src/app.js"></script>
 </body>
 </html>

--- a/src/app.js
+++ b/src/app.js
@@ -1,7 +1,7 @@
 // Three.js via CDN modules (ESM) and helpers from the examples directory.
-import * as THREE from 'https://unpkg.com/three@0.160.0/build/three.module.js';
-import { OrbitControls } from 'https://unpkg.com/three@0.160.0/examples/jsm/controls/OrbitControls.js?module';
-import { STLLoader } from 'https://unpkg.com/three@0.160.0/examples/jsm/loaders/STLLoader.js?module';
+import * as THREE from 'three';
+import { OrbitControls } from 'three/examples/jsm/controls/OrbitControls.js';
+import { STLLoader } from 'three/examples/jsm/loaders/STLLoader.js';
 
 const scene = new THREE.Scene();
 scene.background = new THREE.Color(0x0b1020);


### PR DESCRIPTION
## Summary
- add an import map to ensure Three.js and its helpers resolve to the same CDN build
- update the viewer module imports to use the shared Three.js instance and avoid duplicate loads

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68dc754d5e80832b96e941c1b6c604c5