### PR TITLE
Render each uploaded model in its own viewer window

### DIFF
--- a/index.html
+++ b/index.html
@@ -54,7 +54,9 @@
 
 
 <main class="right">
-<div id="viewer" class="viewer"></div>
+<div id="viewer" class="viewer-grid">
+  <div class="viewer-empty">Load a file to open it in its own window.</div>
+</div>
 <div id="loading" class="loader">Loading…</div>
 <footer class="note">Tip: You can load multiple files; click a row to focus that model.</footer>
 </main>

--- a/styles.css
+++ b/styles.css
@@ -25,7 +25,7 @@ header .tag { font-size: 12px; color: var(--muted); padding: 4px 8px; border:1px
 
 .wrap { display: grid; grid-template-columns: 360px 1fr; height: calc(100% - 62px); }
 .left { border-right: 1px solid #1e274a; background: var(--panel); padding: 16px; overflow:auto; }
-.right { position: relative; }
+.right { position: relative; display:flex; flex-direction:column; }
 .controls { display:flex; flex-direction:column; gap:12px; }
 
 
@@ -58,10 +58,79 @@ select, input[type="number"] { background:#0e1632; border:1px solid #2a3566; col
 .small { font-size: 12px; }
 
 
-.viewer { position:absolute; inset:0; }
+.viewer-grid {
+  position: relative;
+  flex: 1;
+  display: grid;
+  gap: 16px;
+  grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+  padding: 16px;
+  overflow: auto;
+}
+
+.viewer-empty {
+  grid-column: 1 / -1;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  border: 1px dashed #2d3a6b;
+  border-radius: 14px;
+  color: var(--muted);
+  padding: 32px;
+  text-align: center;
+  background: rgba(13, 21, 48, 0.6);
+}
+
+.viewer-window {
+  display: flex;
+  flex-direction: column;
+  background: rgba(13, 21, 48, 0.85);
+  border: 1px solid #232e5d;
+  border-radius: 16px;
+  box-shadow: 0 12px 32px rgba(0, 0, 0, 0.25);
+  overflow: hidden;
+  min-height: 320px;
+  transition: box-shadow 0.2s ease, border-color 0.2s ease;
+}
+
+.viewer-window-title {
+  padding: 12px 16px;
+  font-size: 13px;
+  font-weight: 600;
+  letter-spacing: 0.2px;
+  background: rgba(12, 18, 40, 0.85);
+  border-bottom: 1px solid #1f2850;
+}
+
+.viewer-window--active {
+  border-color: var(--accent);
+  box-shadow: 0 0 0 2px rgba(122, 162, 255, 0.3);
+}
+
+.viewer-canvas {
+  position: relative;
+  flex: 1;
+  min-height: 240px;
+}
+
+.viewer-canvas canvas {
+  display: block;
+  width: 100%;
+  height: 100%;
+}
+
 canvas { display:block; }
 
 
-footer.note { position:absolute; bottom:10px; left:10px; background: rgba(10,14,30,.7); padding:8px 10px; border-radius:10px; border:1px solid #263261; color:var(--muted); font-size:12px; }
+.right footer.note {
+  margin: 0 16px 16px;
+  align-self: flex-start;
+  background: rgba(10,14,30,.7);
+  padding: 8px 10px;
+  border-radius:10px;
+  border:1px solid #263261;
+  color:var(--muted);
+  font-size:12px;
+}
 .loader { display:none; position:absolute; top:12px; right:12px; background:#0d1530; border:1px solid #232e5d; padding:6px 10px; border-radius:10px; font-size:12px; }
 .loader.show { display:block; }


### PR DESCRIPTION
## Summary
- create a viewer manager so every uploaded CAD file is rendered in its own Three.js viewport
- update the layout and styling to show multiple viewer windows in a scrollable grid with empty-state messaging
- keep the upload cards in sync with their viewer windows and improve cleanup on failures

## Testing
- Manual UI verification in browser

------
https://chatgpt.com/codex/tasks/task_e_68dc77e1416c832bb9473dcedd5904cb