### PR TITLE
Fix ViewerManager initialization timing

### DIFF
--- a/src/app.js
+++ b/src/app.js
@@ -25,6 +25,9 @@ const unitToMillimeter = {
 };
 
 function initViewer() {
+  if (!viewerManager) {
+    viewerManager = new ViewerManager(viewerEl);
+  }
   viewerManager.initialize();
 }
 
@@ -554,7 +557,6 @@ class ModelViewport {
   }
 }
 
-viewerManager = new ViewerManager(viewerEl);
 initViewer();
 attachUiHandlers();
 


### PR DESCRIPTION
## Summary
- lazily instantiate the viewer manager inside `initViewer` so initialization happens after the class is available

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dc84cef908832ba9a585c6a62e6550