### PR TITLE
Fix nullish fallback mixing with logical OR

### DIFF
--- a/src/app.js
+++ b/src/app.js
@@ -721,7 +721,7 @@ function summarizeLoop(loop, vertices) {
       { axis: 'z', value: extent.z },
     ].sort((a, b) => a.value - b.value);
     if (axes.length) {
-      const nextValue = axes[1]?.value ?? axes[0].value || 0;
+      const nextValue = axes[1]?.value ?? axes[0].value ?? 0;
       if (axes[0].value <= LOOP_AXIS_IGNORE_TOLERANCE || axes[0].value <= nextValue * 0.2) {
         axisToIgnore = axes[0].axis;
       }


### PR DESCRIPTION
## Summary
- avoid mixing nullish coalescing with logical OR in loop axis evaluation
- ensure the loop axis fallback resolves entirely through nullish coalescing

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dc9356177c832b983c6b5076e8913c