### PR TITLE
Reset DXFLoader metadata before each parse

### DIFF
--- a/src/loaders/DXFLoader.js
+++ b/src/loaders/DXFLoader.js
@@ -84,6 +84,15 @@ export class DXFLoader {
     if (typeof text !== 'string') {
       throw new Error('DXFLoader.parse requires a DXF file as a string.');
     }
+
+    // Reset metadata so each parse call reports fresh information
+    this.metadata = {
+      units: null,
+      bounds: null,
+      layerCount: 0,
+      entityCounts: {},
+    };
+
     const pairs = parsePairs(text);
     if (!pairs.length) {
       throw new Error('DXFLoader: the provided file does not contain any DXF data.');


### PR DESCRIPTION
## Summary
- reset the DXFLoader metadata container at the start of each parse so entity counts and bounds are fresh

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dccbe92144832b9841886fb2a473d8